### PR TITLE
use node18 extension in chat.delta.desktop.yml

### DIFF
--- a/chat.delta.desktop.yml
+++ b/chat.delta.desktop.yml
@@ -5,7 +5,7 @@ runtime: org.freedesktop.Platform
 runtime-version: '22.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions:
-  - org.freedesktop.Sdk.Extension.node16
+  - org.freedesktop.Sdk.Extension.node18
   - org.freedesktop.Sdk.Extension.rust-stable
 command: /app/bin/run.sh
 finish-args:


### PR DESCRIPTION
- node.js 16 has reached EOL, use node.js 18 instead